### PR TITLE
Add config files for intellij

### DIFF
--- a/intellij/Dockerfile
+++ b/intellij/Dockerfile
@@ -5,9 +5,33 @@ MAINTAINER James C. Scott III <jcscott.iii@gmail.com>
 RUN apt-get install -y \
     openjdk-7-jre \
     openjdk-7-jdk \
-    zenity
+    zenity \
+    zip=3.0-8
 RUN apt-get clean
+
+USER $USERNAME
 
 RUN wget -O $HOME/IdeaIC.tar.gz 'https://d1opms6zj7jotq.cloudfront.net/idea/ideaIC-15.0.1.tar.gz'
 RUN mkdir $HOME/intellij && tar -xzf $HOME/IdeaIC.tar.gz -C $HOME/intellij/ --strip-components=1
 RUN ln -s $HOME/intellij/bin/idea.sh $HOME/bin/idea.sh
+
+# Get plugin version from here: https://plugins.jetbrains.com/plugin/5047
+# Current version is 0.10.749
+RUN wget -O $HOME/Go-Plugin.zip 'https://plugins.jetbrains.com/plugin/download?pr=&updateId=22601'
+RUN unzip $HOME/Go-Plugin.zip -d $HOME/intellij/plugins/
+
+# Make sure to use $HOME/.IdeaIC and not $HOME/IdeaICvXY
+RUN grep '# idea.config.path=${user.home}\/.IdeaIC\/config' $HOME/intellij/bin/idea.properties && \
+    sed -i 's/# idea.config.path=${user.home}\/.IdeaIC\/config/idea.config.path=${user.home}\/.IdeaIC\/config/g' $HOME/intellij/bin/idea.properties
+# Add config files
+RUN mkdir -p $HOME/.IdeaIC/config/options/
+ADD recentProjects.xml $HOME/.IdeaIC/config/options/recentProjects.xml
+ADD jdk.table.xml $HOME/.IdeaIC/config/options/jdk.table.xml
+
+# Move back to root for the su in entry.sh
+USER root
+
+# Chown the settings files to non-root user.
+RUN chown -R $USERNAME:$USERNAME $HOME/.IdeaIC/config/options/recentProjects.xml
+RUN chown -R $USERNAME:$USERNAME $HOME/.IdeaIC/config/options/jdk.table.xml
+

--- a/intellij/README.md
+++ b/intellij/README.md
@@ -20,6 +20,7 @@ It includes:
 - Run the Docker container per your OS in the instructions [here](../base/gui/README.md#running) where your `GDEC_IMAGE` equals `jcscottiii/intellij-gdec`
 - Once in the container, run this to start the IDE.
   - `idea.sh &`
+- For more tips on using it, refer to [here](https://github.com/go-lang-plugin-org/go-lang-idea-plugin/wiki/Documentation)
 
 ## Screenshots
 TODO

--- a/intellij/jdk.table.xml
+++ b/intellij/jdk.table.xml
@@ -1,0 +1,29 @@
+<application>
+  <component name="ProjectJdkTable">
+    <jdk version="2">
+      <name value="Go 1.5.2" />
+      <type value="Go SDK" />
+      <version value="1.5.2" />
+      <homePath value="$USER_HOME$/go" />
+      <roots>
+        <annotationsPath>
+          <root type="composite" />
+        </annotationsPath>
+        <classPath>
+          <root type="composite">
+            <root type="simple" url="file://$USER_HOME$/go/src" />
+          </root>
+        </classPath>
+        <javadocPath>
+          <root type="composite" />
+        </javadocPath>
+        <sourcePath>
+          <root type="composite">
+            <root type="simple" url="file://$USER_HOME$/go/src" />
+          </root>
+        </sourcePath>
+      </roots>
+      <additional />
+    </jdk>
+  </component>
+</application>

--- a/intellij/recentProjects.xml
+++ b/intellij/recentProjects.xml
@@ -1,0 +1,5 @@
+<application>
+  <component name="RecentProjectsManager">
+    <option name="lastProjectLocation" value="$USER_HOME$/project/src" />
+  </component>
+</application>


### PR DESCRIPTION
This allows for users to
- Automatically have the Go SDK setup.
- Make the workspace point to $HOME/project which is the GOPATH instead
  of a the default $HOME/IdeaProjects
- Standardized the location of the user config files for easy
  maintenance of the image
